### PR TITLE
Change SonarQube host URL port to 8080

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<spring.version>5.1.2.RELEASE</spring.version>
 		<junit.version>4.11</junit.version>
 		<log4j.version>1.2.17</log4j.version>
-		<sonar.host.url>http://172.31.25.60:9000/</sonar.host.url>
+		<sonar.host.url>http://172.31.25.60:8080/</sonar.host.url>
 		<sonar.login>squ_f5e0666dea36ddceca608e25e29f396a68c575df</sonar.login>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
Updated SonarQube host URL from port 9000 to 8080.